### PR TITLE
Show code and reason for non-1000 close events from server

### DIFF
--- a/bin/wscat
+++ b/bin/wscat
@@ -198,8 +198,12 @@ if (program.listen && program.connect) {
       ws.send(data, { mask: true });
       wsConsole.prompt();
     });
-  }).on('close', function close() {
-    wsConsole.print('disconnected', Console.Colors.Green);
+  }).on('close', function close(code, description) {
+    var msg = 'disconnected';
+    if (code != 1000) {
+        msg += ' with error ' + code + (description ? ': ' + description : '');
+    }
+    wsConsole.print(msg, Console.Colors.Green);
     wsConsole.clear();
     process.exit();
   }).on('error', function error(code, description) {


### PR DESCRIPTION
Currently, if the server closes the connection with an error code, the code and reason aren't shown in the console:

```
> foo
disconnected
```

This patch them to the "disconnected" line:

```
> foo
disconnected with error 4400: Error parsing JSON
```