### PR TITLE
Add support for hexadecimal input/output

### DIFF
--- a/bin/wscat
+++ b/bin/wscat
@@ -113,6 +113,8 @@ program
   .option('-n, --no-check', 'Do not check for unauthorized certificates')
   .option('-H, --header <header:value>', 'Set an HTTP header. Repeat to set multiple. (--connect only)', appender(), [])
   .option('--auth <username:password>', 'Add basic HTTP authentication header. (--connect only)')
+  .option('--hex-in', 'Read input lines as hexadecimal (separate bytes with spaces)')
+  .option('--hex-out', 'Output as hexadecimal')
   .parse(process.argv);
 
 if (program.listen && program.connect) {
@@ -144,6 +146,13 @@ if (program.listen && program.connect) {
 
   wsConsole.on('line', function line(data) {
     if (ws) {
+      if (options.hexIn) {
+        var bytes = data.split(' ');
+        data = '';
+        for (var i = 0; i < bytes.length; i++) {
+          data += String.fromCharCode(Number.parseInt(bytes[i], 16));
+        }
+      }
       ws.send(data, { mask: false });
       wsConsole.prompt();
     }
@@ -165,6 +174,28 @@ if (program.listen && program.connect) {
     }).on('error', function error(code, description) {
       wsConsole.print('error: ' + code + (description ? ' ' + description : ''), Console.Colors.Yellow);
     }).on('message', function message(data, flags) {
+      if (program.hexOut) {
+        if (data instanceof Buffer) {
+          o = '';
+          for (var i=0; i<data.length; i++) {
+            o += data.readUIntBE(i, 1).toString(16) + ' ';
+          }
+          data = o;
+        } else if (data instanceof ArrayBuffer) {
+          var view = new Uint8Array(data);
+          var o = '';
+          for (var i=0; i<data.byteLength; i++) {
+            o += view[i].toString(16) + ' ';
+          }
+          data = o;
+        } else if (typeof(data) === 'string') {
+          var o = '';
+          data.split('').forEach(function(c) {
+            o += c.charCodeAt(0).toString(16) + ' ';
+          })
+          data = o;
+        }
+      }
       wsConsole.print('< ' + data, Console.Colors.Blue);
     });
   }).on('error', function servererrror(error) {
@@ -195,6 +226,13 @@ if (program.listen && program.connect) {
   ws.on('open', function open() {
     wsConsole.print('connected (press CTRL+C to quit)', Console.Colors.Green);
     wsConsole.on('line', function line(data) {
+      if (program.hexIn) {
+        var bytes = data.split(' ');
+        data = '';
+        for (var i = 0; i < bytes.length; i++) {
+          data += String.fromCharCode(Number.parseInt(bytes[i], 16));
+        }
+      }
       ws.send(data, { mask: true });
       wsConsole.prompt();
     });
@@ -213,7 +251,7 @@ if (program.listen && program.connect) {
     if (!ws) return;
 
     try { ws.close(); }
-    catch(e) {} 
+    catch(e) {}
 
     process.exit();
   });


### PR DESCRIPTION
This PR adds two options: `--hex-in` and `--hex-out`.

If `--hex-in` is set, input is interpreted as space-separated bytes. E.g., `6a 61 7a 7a 70 69` is interpreted as `jazzpi`.

If `--hex-out` is set, anything coming in to the websocket is printed as space-separated bytes. E.g., if wscat is running in `--listen`-mode and a client sends `jazzpi`, it's printed out as `6a 61 7a 7a 70 69`.

Note: I'm not quite sure about the internals of `ws`, so I just was cautious and implemented Hex conversion for `Buffer`s, `ArrayBuffer`s and `string`s (see lines 177-198).