### PR TITLE
Additions to wscat to improve usage for debugging

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,16 +9,81 @@ This module needs to be installed globally so use the `-g` flag when installing:
 ```
 npm install -g wscat
 ```
-
-## Usage
-
+## Help
 ```
-$ wscat -c ws://echo.websocket.org 
-connected (press CTRL+C to quit)
-> hi there
-< hi there
-> are you a happy parrot?
-< are you a happy parrot?
+Usage: wscat [options] (--listen <port> | --connect <url>)
+
+  Options:
+
+    -h, --help                    output usage information
+    -V, --version                 output the version number
+    -l, --listen <port>           listen on port
+    -c, --connect <url>           connect to a websocket server
+    -p, --protocol <version>      optional protocol version
+    -o, --origin <origin>         optional origin
+    --host <host>                 optional host
+    -s, --subprotocol <protocol>  optional subprotocol
+    -n, --no-check                Do not check for unauthorized certificates
+    -H, --header <header:value>   Set an HTTP header. Repeat to set multiple. (--connect only)
+    --auth <username:password>    Add basic HTTP authentication header. (--connect only)
+    -k, --keepalive <interval>    send a ping every interval seconds
+    -P, --parsecommands           parse input for commands (send, ping, pong, close, etc.)
+```
+## Examples
+
+### Using original behavior:
+```
+$wscat -c wss://echo.websocket.org
+
+connected (press CTRL+C to terminate)
+> hello
+< hello
+```
+### Using --parsecommands
+```
+$wscat -c wss://echo.websocket.org --parsecommands
+
+connected (press CTRL+C to terminate)
+'> send <message>' to send <message> to server
+'> ping' to send a ping to the server
+'> pong' to send pong to the server
+'> close' to gracefully close connection to the server
+'> last' to reprint last received message
+'> counts' to print frame counts
+>
+>
+> ping
+
+ping sent
+
+pong Received
+> send hello
+
+sent (hello)
+
+< hello
+> counts
+Connection Open for 67305 ms
+1 message(s) Received
+1 message(s) Sent
+0 ping(s) Received
+1 ping(s) Sent
+1 pong(s) Received
+0 pong(s) Sent
+Last Message Received =
+hello
+> close
+Connection Closed
+Connection Open for 102873 ms
+1 message(s) Received
+1 message(s) Sent
+0 ping(s) Received
+1 ping(s) Sent
+1 pong(s) Received
+0 pong(s) Sent
+Last Message Received =
+hello
+> ConnectionLasted: 102883ms
 ```
 
 ## License

--- a/bin/wscat
+++ b/bin/wscat
@@ -17,19 +17,93 @@ var program = require('commander')
   , util = require('util')
   , fs = require('fs');
 
+var interval = null;
+var messagesSent = 0;
+var messagesReceived = 0;
+var pingsSent = 0;
+var pingsReceived = 0;
+var pongsSent = 0;
+var pongsReceived = 0;
+var lastMessage = null;
+var connectionStartTime;
+var connectionEndTime;
+function printCounts() {
+  var currentTime = new Date()
+  wsConsole.print('Connection Open for ' + (currentTime - connectionStartTime) + ' ms', Console.Colors.Green);
+  wsConsole.print(messagesReceived + ' message(s) Received', Console.Colors.Green);
+  wsConsole.print(messagesSent + ' message(s) Sent', Console.Colors.Green);
+  wsConsole.print(pingsReceived + ' ping(s) Received', Console.Colors.Green);
+  wsConsole.print(pingsSent + ' ping(s) Sent', Console.Colors.Green);
+  wsConsole.print(pongsReceived + ' pong(s) Received', Console.Colors.Green);
+  wsConsole.print(pongsSent + ' pong(s) Sent', Console.Colors.Green);
+  if (lastMessage) {
+    wsConsole.print('Last Message Received = ', Console.Colors.Green);
+    wsConsole.print(lastMessage, Console.Colors.Default);
+  }
+}
+function printCommands(){
+  wsConsole.print('\'> send <message>\' to send <message> to server', Console.Colors.Green);
+  wsConsole.print('\'> ping\' to send a ping to the server', Console.Colors.Green);
+  wsConsole.print('\'> pong\' to send pong to the server', Console.Colors.Green);
+  wsConsole.print('\'> close\' to gracefully close connection to the server', Console.Colors.Green);
+  wsConsole.print('\'> last\' to reprint last received message', Console.Colors.Green);
+  wsConsole.print('\'> counts\' to print frame counts', Console.Colors.Green);
+}
+function parseInput(data){
+  if (program.parsecommands) {
+    if (data.substring(0, 'send '.length) === 'send ') {
+      ws.send(data.substring('send '.length, data.length), {
+        mask: true
+      });
+      wsConsole.print('sent (' + data.substring('send '.length, data.length) + ')', Console.Colors.Green);
+      messagesSent++;
+    }
+    if (data.substring(0, 'ping'.length) === 'ping') {
+      ws.ping();
+      pingsSent++;
+      wsConsole.print('ping sent', Console.Colors.Green);
+    }
+    if (data.substring(0, 'pong'.length) === 'pong') {
+      ws.pong();
+      pongsSent++;
+      wsConsole.print('pong sent', Console.Colors.Green);
+    }
+    if (data.substring(0, 'close'.length) === 'close') {
+      ws.close(1001, 'Client Closing.');
+      wsConsole.print('Connection Closed', Console.Colors.Green);
+      printCounts();
+      console.timeEnd('ConnectionLasted');
+      process.exit();
+    }
+    if (data.substring(0, 'last'.length) === 'last') {
+      if (lastMessage) {
+        wsConsole.print('Last Message Recieved = ', Console.Colors.Green);
+        wsConsole.print(lastMessage, Console.Colors.Default);
+      }
+    }
+    if (data.substring(0, 'counts'.length) === 'counts') {
+      printCounts();
+    }
+  } else {
+    ws.send(data, {
+      mask: true
+    });
+    messagesSent++;
+  }
+  wsConsole.prompt();
+}
 /**
  * InputReader - processes console input.
  */
+
 function Console() {
   if (!(this instanceof Console)) return new Console();
-
   this.stdin = process.stdin;
   this.stdout = process.stdout;
 
   this.readlineInterface = readline.createInterface(this.stdin, this.stdout);
 
   var self = this;
-
   this.readlineInterface.on('line', function line(data) {
     self.emit('line', data);
   }).on('close', function close() {
@@ -40,7 +114,6 @@ function Console() {
     self.clear();
   };
 }
-
 util.inherits(Console, events.EventEmitter);
 
 Console.Colors = {
@@ -113,6 +186,8 @@ program
   .option('-n, --no-check', 'Do not check for unauthorized certificates')
   .option('-H, --header <header:value>', 'Set an HTTP header. Repeat to set multiple. (--connect only)', appender(), [])
   .option('--auth <username:password>', 'Add basic HTTP authentication header. (--connect only)')
+  .option('-k, --keepalive <interval>', 'send a ping every interval seconds')
+  .option('-P, --parsecommands', 'parse input for commands (send, ping, pong, close, etc.)')
   .parse(process.argv);
 
 if (program.listen && program.connect) {
@@ -132,6 +207,9 @@ if (program.listen && program.connect) {
   var ws = null;
   var wss = new WebSocket.Server({ port: program.listen }, function listening() {
     wsConsole.print('listening on port ' + program.listen + ' (press CTRL+C to quit)', Console.Colors.Green);
+    if (program.parsecommands) {
+      printCommands();
+    }
     wsConsole.clear();
   });
 
@@ -142,30 +220,51 @@ if (program.listen && program.connect) {
     process.exit(0);
   });
 
-  wsConsole.on('line', function line(data) {
-    if (ws) {
-      ws.send(data, { mask: false });
-      wsConsole.prompt();
-    }
-  });
-
+  wsConsole.on('line', parseInput);
   wss.on('connection', function(newClient) {
-    if (ws) return newClient.terminate();
-
+    if (ws) {
+      // limit to one client
+      newClient.terminate();
+      return;
+    };
     ws = newClient;
     wsConsole.resume();
     wsConsole.prompt();
     wsConsole.print('client connected', Console.Colors.Green);
-
+    console.time('ConnectionLasted');
+    connectionStartTime = new Date();
+    if (program.keepalive) {
+      interval = setInterval(function() {
+        ws.ping();
+        pingsSent++;
+        wsConsole.print('ping sent', Console.Colors.Green);
+      }, program.keepalive);
+    }
     ws.on('close', function close() {
       wsConsole.print('disconnected', Console.Colors.Green);
+      printCounts();
+      console.timeEnd('ConnectionLasted');
+
+      if (interval != null) {
+        clearInterval(interval);
+      }
       wsConsole.clear();
       wsConsole.pause();
       ws = null;
-    }).on('error', function error(code, description) {
+    }).on('error', function(code, description) {
       wsConsole.print('error: ' + code + (description ? ' ' + description : ''), Console.Colors.Yellow);
     }).on('message', function message(data, flags) {
-      wsConsole.print('< ' + data, Console.Colors.Blue);
+      lastMessage = data;
+      wsConsole.print('< ' + data, Console.Colors.Default);
+      messagesReceived++;
+    }).on('pong', function(data, flags) {
+      pongsReceived++;
+      wsConsole.print('pong Received', Console.Colors.Green);
+    }).on('ping', function(data, flags) {
+      pingsReceived++;
+      pongsSent++;
+      ws.pong();
+      wsConsole.print('pong sent', Console.Colors.Green);
     });
   }).on('error', function servererrror(error) {
     wsConsole.print('error: ' + error.toString(), Console.Colors.Yellow);
@@ -174,7 +273,6 @@ if (program.listen && program.connect) {
 } else if (program.connect) {
   var wsConsole = new Console();
   var options = {};
-
   if (program.protocol) options.protocolVersion = program.protocol;
   if (program.origin) options.origin = program.origin;
   if (program.subprotocol) options.protocol = program.subprotocol;
@@ -198,30 +296,56 @@ if (program.listen && program.connect) {
   var ws = new WebSocket(connectUrl, options);
 
   ws.on('open', function open() {
-    wsConsole.print('connected (press CTRL+C to quit)', Console.Colors.Green);
-    wsConsole.on('line', function line(data) {
-      ws.send(data, { mask: true });
-      wsConsole.prompt();
-    });
+    console.time('ConnectionLasted');
+    connectionStartTime = new Date();
+    if (program.keepalive) {
+      interval = setInterval(function() {
+        ws.ping();
+        pingsSent++;
+        wsConsole.print('ping sent', Console.Colors.Green);
+      }, program.keepalive);
+    }
+    wsConsole.print('connected (press CTRL+C to terminate)', Console.Colors.Green);
+    if (program.parsecommands) {
+      printCommands();
+    }
+    wsConsole.on('line', parseInput);
   }).on('close', function close() {
     wsConsole.print('disconnected', Console.Colors.Green);
+    printCounts();
+    console.timeEnd('ConnectionLasted');
+    if (interval != null) {
+      clearInterval(interval);
+    }
     wsConsole.clear();
     process.exit();
+
   }).on('error', function error(code, description) {
+    printCounts();
     wsConsole.print('error: ' + code + (description ? ' ' + description : ''), Console.Colors.Yellow);
     process.exit(-1);
   }).on('message', function message(data, flags) {
-    wsConsole.print('< ' + data, Console.Colors.Blue);
+    messagesReceived++;
+    lastMessage = data;
+    wsConsole.print('< ' + data, Console.Colors.Default);
+  }).on('pong', function pong(data, flags) {
+    pongsReceived++;
+    wsConsole.print('pong Received', Console.Colors.Green);
+  }).on('ping', function ping(data, flags) {
+    pingsReceived++;
+    pongsSent++;
+    ws.pong();
+    wsConsole.print('pong sent', Console.Colors.Green);
   });
-
   wsConsole.on('close', function close() {
+    printCounts();
     if (!ws) return;
 
     try { ws.close(); }
-    catch(e) {} 
+    catch(e) {}
 
     process.exit();
-  });
+});
 } else {
   program.help();
 }


### PR DESCRIPTION
I've made some changes to wscat (but also preserved the majority of previous behavior) that I think may be useful to others.


Added new behaviors:
--parsecommands option to trigger pings and pongs, and other commands such as close, last, counts
--keepalive option to send a ping on an interval (to keep a connection alive)

Added statistic trackers:
Frame counts (messages, pings, pongs, etc.)
Connection times

Thanks,

Jonathan