### PR TITLE
Add -m (Send initial message)

### DIFF
--- a/bin/wscat
+++ b/bin/wscat
@@ -106,7 +106,7 @@ program
   .usage('[options] (--listen <port> | --connect <url>)')
   .option('-l, --listen <port>', 'listen on port')
   .option('-c, --connect <url>', 'connect to a websocket server')
-  .option('-m, --message <message>', 'initial message to send')
+  .option('-m, --message <message>', 'initial message to send', appender(), [])
   .option('-p, --protocol <version>', 'optional protocol version')
   .option('-o, --origin <origin>', 'optional origin')
   .option('--host <host>', 'optional host')
@@ -201,10 +201,10 @@ if (program.listen && program.connect) {
   ws.on('open', function open() {
     wsConsole.print('connected (press CTRL+C to quit)', Console.Colors.Green);
 
-    if (program.message) {
-      ws.send(program.message);
-      wsConsole.print('> ' + program.message);
-    }
+    (program.message || []).forEach(function messager(s) {
+      ws.send(s);
+      wsConsole.print('> ' + s);
+    });
 
     wsConsole.on('line', function line(data) {
       ws.send(data, { mask: true });

--- a/bin/wscat
+++ b/bin/wscat
@@ -106,6 +106,7 @@ program
   .usage('[options] (--listen <port> | --connect <url>)')
   .option('-l, --listen <port>', 'listen on port')
   .option('-c, --connect <url>', 'connect to a websocket server')
+  .option('-m, --message <message>', 'initial message to send')
   .option('-p, --protocol <version>', 'optional protocol version')
   .option('-o, --origin <origin>', 'optional origin')
   .option('--host <host>', 'optional host')
@@ -199,6 +200,12 @@ if (program.listen && program.connect) {
 
   ws.on('open', function open() {
     wsConsole.print('connected (press CTRL+C to quit)', Console.Colors.Green);
+
+    if (program.message) {
+      ws.send(program.message);
+      wsConsole.print('> ' + program.message);
+    }
+
     wsConsole.on('line', function line(data) {
       ws.send(data, { mask: true });
       wsConsole.prompt();
@@ -218,7 +225,7 @@ if (program.listen && program.connect) {
     if (!ws) return;
 
     try { ws.close(); }
-    catch(e) {} 
+    catch(e) {}
 
     process.exit();
   });


### PR DESCRIPTION
# Why
Where I work we stream loads of market data, and the client is the boss of what it would like to stream. It can decide to stream the Oslo stock exchange in real time, for example. This we do via a `subscribe` string.

When working with services that use websockets, we usually don't get it right the first time. This means that we have to work on our servlet, then use `wscat` to check the data is correct, make changes and restart. It would be great to be able to just use *arrow up* to do the same subscribe, and not have to have the subscribe string in notepad on the side, using copy and paste to get the data out from the server.

It is also useful to be able to send a single wscat command to another developer, and not two commands they have to do in sequence. Minor, but a quality of life bump that is much appreciated.

This change would also make scripting easier, as you could simply pipe the command into `grep`, `awk`, etc, without having to do clever bash workarounds to send that inital message.

# What

This PR adds a new argument, `-m, --message`.  This tells wscat to send the provided message to the server as soon as it is ready.

# Result
```bash
$ wscat -c wss://bors.e24.no/server/components --message 'subscribe?columns=LONG_NAME&itemSector=OSEBX.OSE'
connected (press CTRL+C to quit)
> subscribe?columns=LONG_NAME&itemSector=OSEBX.OSE
< {"id":"dc5b617c656a177415aa7417ef332af6","channel":null}
< {"id":"dc5b617c656a177415aa7417ef332af6","values":{"LONG_NAME":"Hovedindeksen"},"type":"new","key":"OSEBX_OSE"}
>
```