### PR TITLE
Keep-Open Option

### DIFF
--- a/bin/wscat
+++ b/bin/wscat
@@ -133,6 +133,7 @@ program
   .option('--cert <cert>', 'Specify a Client SSL Certificate (--connect only)')
   .option('--key <key>', 'Specify a Client SSL Certificate\'s key (--connect only)')
   .option('--passphrase [passphrase]', 'Specify a Client SSL Certificate Key\'s passphrase (--connect only). If you don\'t provide a value, it will be prompted for.')
+  .option('-k, --keep-open', 'Keep the socket open, even after receiving EOF. Useful in conjunction with echo')
   .parse(process.argv);
 
 if (program.listen && program.connect) {
@@ -230,8 +231,10 @@ if (program.listen && program.connect) {
     });
 
     wsConsole.on('close', function close() {
-      ws.close();
-      process.exit();
+      if(!program['keepOpen']) {
+        ws.close();
+        process.exit();
+      }
     });
   };
   if (program.passphrase === true) {


### PR DESCRIPTION
Hi -

I have a use case for wscat, where I need to send a message to a remote server, and then leave the connection open, so I can receive the responses. As such, I added a simple "keep-open" flag, which doesn't close the web socket or exit the process after the console is closed. This allows wscat to be used in conjunction with echo/cat/etc and an input pipe:

`echo '{"type":"message-type"}' | wscat --keep-open -connect localhost:80`

Creating a pull request in case this might be useful to others.

Cheers,
-Courtland