### PR TITLE
Added a quiet mode

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,6 +12,7 @@ npm install -g wscat
 
 ## Usage
 
+### Connect
 ```
 $ wscat -c ws://echo.websocket.org 
 connected (press CTRL+C to quit)
@@ -19,6 +20,39 @@ connected (press CTRL+C to quit)
 < hi there
 > are you a happy parrot?
 < are you a happy parrot?
+```
+
+### Control Frames
+To issue control frames, start wscat with `--slash`, i.e.
+```
+$ wscat --slash -c ws://echo.websocket.org
+connected (press CTRL+C to quit)
+> /ping
+< Received pong
+```
+
+By default wscat will print to console when it recieves a ping, which can mess
+up the users typing, i.e.
+```
+$ wscat -c ws://echo.websocket.org
+connected (press CTRL+C to quit)
+< Received ping
+< Received ping
+            < Received ping
+> w are youHello user ho 		# Typed Hello user how are you
+< Received ping
+```
+
+By using `--quiet` pings will be recieved and a pong will be sent back in the
+background, and not be printed to console. All other control frames will be
+visible, i.e.
+```
+$ wscat --slash --quiet --ws://echo.websocket.org
+> Hello
+> /ping
+< Received pong
+> How are you?
+> 'Look ma, know ping messages'
 ```
 
 ## License

--- a/bin/wscat
+++ b/bin/wscat
@@ -145,6 +145,10 @@ program
     'Enable slash commands for control frames ' +
       '(/ping, /pong, /close [code [, reason]])'
   )
+  .option(
+    '--quiet',
+    'Stops incoming ping control frame being printed to console.'
+  )
   .parse(process.argv);
 
 if (program.listen && program.connect) {
@@ -323,11 +327,13 @@ if (program.listen) {
     });
 
     ws.on('ping', () => {
-      wsConsole.print(
-        Console.Types.Incoming,
-        'Received ping',
-        Console.Colors.Blue
-      );
+      if (!program.quiet){
+        wsConsole.print(
+          Console.Types.Incoming,
+          'Received ping',
+          Console.Colors.Blue
+        );
+      }
     });
 
     ws.on('pong', () => {

--- a/bin/wscat
+++ b/bin/wscat
@@ -146,7 +146,7 @@ program
       '(/ping, /pong, /close [code [, reason]])'
   )
   .option(
-    '--quiet',
+    '-q, --quiet',
     'Stops incoming ping control frame being printed to console.'
   )
   .parse(process.argv);


### PR DESCRIPTION
I was testing a service that pinged a lot, and would interrupt typing, so I added a flag `-q, --quiet` that would silence the ping control frame (pong and close control frames handled same as usual) from the console.

May be useful for others 🤷‍♂️ 😄 
