### PR TITLE
add proxy support to connect

### DIFF
--- a/bin/wscat
+++ b/bin/wscat
@@ -13,6 +13,7 @@ const read = require('read');
 const readline = require('readline');
 const tty = require('tty');
 const WebSocket = require('ws');
+const HttpsProxyAgent = require('https-proxy-agent');
 
 /**
  * InputReader - processes console input.
@@ -145,6 +146,9 @@ program
     'Enable slash commands for control frames ' +
       '(/ping, /pong, /close [code [, reason]])'
   )
+  .option(
+    '--proxy <[protocol://]host[:port]>',
+    'Use proxy on given port (--connect only).')
   .parse(process.argv);
 
 if (program.listen && program.connect) {
@@ -238,6 +242,11 @@ if (program.listen) {
     if (program.ca) options.ca = fs.readFileSync(program.ca);
     if (program.cert) options.cert = fs.readFileSync(program.cert);
     if (program.key) options.key = fs.readFileSync(program.key);
+
+    if (program.proxy) {
+      var agent = new HttpsProxyAgent(program.proxy);
+      options.agent = agent
+    }
 
     let connectUrl = program.connect;
     if (!connectUrl.match(/\w+:\/\/.*$/i)) {

--- a/bin/wscat
+++ b/bin/wscat
@@ -148,7 +148,9 @@ program
   )
   .option(
     '--proxy <[protocol://]host[:port]>',
-    'Use proxy on given port (--connect only).')
+    'Use proxy on given port (--connect only). ' +
+    'Proxy must support CONNECT method.'
+  )
   .parse(process.argv);
 
 if (program.listen && program.connect) {

--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
   "license": "MIT",
   "dependencies": {
     "commander": "~3.0.0",
-    "https-proxy-agent": "^2.2.2",
+    "https-proxy-agent": "^3.0.0",
     "read": "~1.0.7",
     "ws": "~7.1.0"
   },

--- a/package.json
+++ b/package.json
@@ -19,6 +19,7 @@
   "license": "MIT",
   "dependencies": {
     "commander": "~3.0.0",
+    "https-proxy-agent": "^2.2.2",
     "read": "~1.0.7",
     "ws": "~7.1.0"
   },


### PR DESCRIPTION
fixes #54 

Adds a new --proxy flag that will implement an https-proxy-agent and use the proxy specified.

Used this to test if my proxy could handle WebSocket connections and worked like a charm.
Thought I'd do a PR for this since there was some interest at some point.