### PR TITLE
[minor] added --print-reason cli argument for ws close reason

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,6 +23,7 @@ Options:
   -o, --origin <origin>               optional origin
   -x, --execute <command>             execute command after connecting
   -w, --wait <seconds>                wait given seconds after executing command
+  -r, --print-reason                  print reason string when the connection closes
   --host <host>                       optional host
   -s, --subprotocol <protocol>        optional subprotocol (default: [])
   -n, --no-check                      do not check for unauthorized certificates

--- a/bin/wscat
+++ b/bin/wscat
@@ -93,6 +93,23 @@ class Console extends EventEmitter {
   resume() {
     this.stdin.removeListener('keypress', this._resetInput);
   }
+
+  // helper print function, not core to Console features
+  printClose(code, reason) {
+    if (reason && program.printReason) {
+      this.print(
+        Console.Types.Control,
+        `Disconnected (code: ${code}, reason: ${reason})`,
+        Console.Colors.Green
+      );
+    } else {
+      this.print(
+        Console.Types.Control,
+        `Disconnected (code: ${code})`,
+        Console.Colors.Green
+      );
+    }
+  }
 }
 
 function collect(val, memo) {
@@ -101,6 +118,7 @@ function collect(val, memo) {
 }
 
 function noop() {}
+
 
 /**
  * The actual application
@@ -116,6 +134,7 @@ program
   .option('-o, --origin <origin>', 'optional origin')
   .option('-x, --execute <command>', 'execute command after connecting')
   .option('-w, --wait <seconds>', 'wait given seconds after executing command')
+  .option('-r, --print-reason', 'print reason string when the connection closes')
   .option('--host <host>', 'optional host')
   .option('-s, --subprotocol <protocol>', 'optional subprotocol', collect, [])
   .option('-n, --no-check', 'do not check for unauthorized certificates')
@@ -195,12 +214,8 @@ if (program.listen) {
       Console.Colors.Green
     );
 
-    ws.on('close', (code) => {
-      wsConsole.print(
-        Console.Types.Control,
-        `Disconnected (code: ${code})`,
-        Console.Colors.Green
-      );
+    ws.on('close', (code, reason) => {
+      wsConsole.printClose(code, reason)
       wsConsole.clear();
       wsConsole.pause();
       ws = null;
@@ -314,13 +329,9 @@ if (program.listen) {
       }
     });
 
-    ws.on('close', (code) => {
+    ws.on('close', (code, reason) => {
       if (!program.execute) {
-        wsConsole.print(
-          Console.Types.Control,
-          `Disconnected (code: ${code})`,
-          Console.Colors.Green
-        );
+        wsConsole.printClose(code, reason);
       }
       wsConsole.clear();
       process.exit();


### PR DESCRIPTION
intended to solve https://github.com/websockets/wscat/issues/108

## functionality
when using `-r` or `--print-reason`, when the ws closes and the server sends a reason string, the console will exit with `Disconnected (code: 4001, reason: some reason)` instead of the current `Disconnected (code: 4001)`.

This is opt-in, to keep the change minor.

## display considerations
Maybe we want to give even more space to the reason, and bring it in its own line, without wrapping it in brackets, as the server might send a multi-line reason

## implementation considerations
I've implemented this as a method of `wsConsole` to avoid code duplication, but it doesn't feel like it would belong there. Having a helper function to do this would need to have `wsConsole` passed to it, as the disconnect message is sent in two places that reference different `wsConsole`s. I tend to avoid `f(obj, ..params)` when almost everywhere `obj.f(...params)` is used. I'll leave this up for discussion.

## security considerations
Currently `reason` is simply injected into the string to print, it's not sanitized by me. At best this means the server can change colors or ring bells in your terminal when the ws closes, at worst it could open the user up to remote code execution, depending on their terminal.

Maybe this is fine, as wscat is mostly a debugging tool for APIs that you don't tend to consider malign. If it's not, I don't have in mind a best strategy to sanitize for all terminals other than only keeping ascii printable characters, or JSON.stringifying the whole string