### PR TITLE
[minor] added --hide-ping for hiding 'Received ping' and pong messages

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,6 +23,7 @@ Options:
   -o, --origin <origin>               optional origin
   -x, --execute <command>             execute command after connecting
   -w, --wait <seconds>                wait given seconds after executing command
+  -P, --hide-ping                     hide internal ping/pong messages
   --host <host>                       optional host
   -s, --subprotocol <protocol>        optional subprotocol (default: [])
   -n, --no-check                      do not check for unauthorized certificates

--- a/bin/wscat
+++ b/bin/wscat
@@ -116,6 +116,7 @@ program
   .option('-o, --origin <origin>', 'optional origin')
   .option('-x, --execute <command>', 'execute command after connecting')
   .option('-w, --wait <seconds>', 'wait given seconds after executing command')
+  .option('-P, --hide-ping', 'hide internal ping/pong messages')
   .option('--host <host>', 'optional host')
   .option('-s, --subprotocol <protocol>', 'optional subprotocol', collect, [])
   .option('-n, --no-check', 'do not check for unauthorized certificates')
@@ -336,19 +337,23 @@ if (program.listen) {
     });
 
     ws.on('ping', () => {
-      wsConsole.print(
-        Console.Types.Incoming,
-        'Received ping',
-        Console.Colors.Blue
-      );
+      if (!program.hidePing) {
+        wsConsole.print(
+          Console.Types.Incoming,
+          'Received ping',
+          Console.Colors.Blue
+        );
+      }
     });
 
     ws.on('pong', () => {
-      wsConsole.print(
-        Console.Types.Incoming,
-        'Received pong',
-        Console.Colors.Blue
-      );
+      if (!program.hidePing) {
+        wsConsole.print(
+          Console.Types.Incoming,
+          'Received pong',
+          Console.Colors.Blue
+        );
+      }
     });
 
     wsConsole.on('close', () => {


### PR DESCRIPTION
intended to fix https://github.com/websockets/wscat/issues/107 and provide a workaround for https://github.com/websockets/wscat/issues/84

## functionality
When using a `-P` or `--hide-ping`, the blue `< Received ping` (and pong) messages stop appearing in the console, which allows for a clean uninterrupted copy-pasteable transcript of the ws conversation.

This is opt-in to keep the change minor. I would suggest to make this default in the next major version