### PR TITLE
print ws close reason string from server at the end of the connection

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,6 +23,7 @@ Options:
   -o, --origin <origin>               optional origin
   -x, --execute <command>             execute command after connecting
   -w, --wait <seconds>                wait given seconds after executing command
+  -r, --print-reason                  print reason string when the connection closes
   --host <host>                       optional host
   -s, --subprotocol <protocol>        optional subprotocol (default: [])
   -n, --no-check                      do not check for unauthorized certificates

--- a/README.md
+++ b/README.md
@@ -23,7 +23,6 @@ Options:
   -o, --origin <origin>               optional origin
   -x, --execute <command>             execute command after connecting
   -w, --wait <seconds>                wait given seconds after executing command
-  -r, --print-reason                  print reason string when the connection closes
   --host <host>                       optional host
   -s, --subprotocol <protocol>        optional subprotocol (default: [])
   -n, --no-check                      do not check for unauthorized certificates

--- a/bin/wscat
+++ b/bin/wscat
@@ -96,7 +96,7 @@ class Console extends EventEmitter {
 
   // helper print function, not core to Console features
   printClose(code, reason) {
-    if (reason && program.printReason) {
+    if (reason) {
       this.print(
         Console.Types.Control,
         `Disconnected (code: ${code}, reason: ${reason})`,
@@ -134,7 +134,6 @@ program
   .option('-o, --origin <origin>', 'optional origin')
   .option('-x, --execute <command>', 'execute command after connecting')
   .option('-w, --wait <seconds>', 'wait given seconds after executing command')
-  .option('-r, --print-reason', 'print reason string when the connection closes')
   .option('--host <host>', 'optional host')
   .option('-s, --subprotocol <protocol>', 'optional subprotocol', collect, [])
   .option('-n, --no-check', 'do not check for unauthorized certificates')

--- a/bin/wscat
+++ b/bin/wscat
@@ -93,23 +93,6 @@ class Console extends EventEmitter {
   resume() {
     this.stdin.removeListener('keypress', this._resetInput);
   }
-
-  // helper print function, not core to Console features
-  printClose(code, reason) {
-    if (reason) {
-      this.print(
-        Console.Types.Control,
-        `Disconnected (code: ${code}, reason: ${reason})`,
-        Console.Colors.Green
-      );
-    } else {
-      this.print(
-        Console.Types.Control,
-        `Disconnected (code: ${code})`,
-        Console.Colors.Green
-      );
-    }
-  }
 }
 
 function collect(val, memo) {
@@ -214,7 +197,11 @@ if (program.listen) {
     );
 
     ws.on('close', (code, reason) => {
-      wsConsole.printClose(code, reason)
+      wsConsole.print(
+        Console.Types.Control,
+        `Disconnected (code: ${code}, reason: "${reason}")`,
+        Console.Colors.Green
+      );
       wsConsole.clear();
       wsConsole.pause();
       ws = null;
@@ -330,7 +317,11 @@ if (program.listen) {
 
     ws.on('close', (code, reason) => {
       if (!program.execute) {
-        wsConsole.printClose(code, reason);
+        wsConsole.print(
+          Console.Types.Control,
+          `Disconnected (code: ${code}, reason: "${reason}")`,
+          Console.Colors.Green
+        );
       }
       wsConsole.clear();
       process.exit();

--- a/bin/wscat
+++ b/bin/wscat
@@ -93,6 +93,23 @@ class Console extends EventEmitter {
   resume() {
     this.stdin.removeListener('keypress', this._resetInput);
   }
+
+  // helper print function, not core to Console features
+  printClose(code, reason) {
+    if (reason && program.printReason) {
+      this.print(
+        Console.Types.Control,
+        `Disconnected (code: ${code}, reason: ${reason})`,
+        Console.Colors.Green
+      );
+    } else {
+      this.print(
+        Console.Types.Control,
+        `Disconnected (code: ${code})`,
+        Console.Colors.Green
+      );
+    }
+  }
 }
 
 function collect(val, memo) {
@@ -101,6 +118,7 @@ function collect(val, memo) {
 }
 
 function noop() {}
+
 
 /**
  * The actual application
@@ -116,6 +134,7 @@ program
   .option('-o, --origin <origin>', 'optional origin')
   .option('-x, --execute <command>', 'execute command after connecting')
   .option('-w, --wait <seconds>', 'wait given seconds after executing command')
+  .option('-r, --print-reason', 'print reason string when the connection closes')
   .option('--host <host>', 'optional host')
   .option('-s, --subprotocol <protocol>', 'optional subprotocol', collect, [])
   .option('-n, --no-check', 'do not check for unauthorized certificates')
@@ -195,12 +214,8 @@ if (program.listen) {
       Console.Colors.Green
     );
 
-    ws.on('close', (code) => {
-      wsConsole.print(
-        Console.Types.Control,
-        `Disconnected (code: ${code})`,
-        Console.Colors.Green
-      );
+    ws.on('close', (code, reason) => {
+      wsConsole.printClose(code, reason)
       wsConsole.clear();
       wsConsole.pause();
       ws = null;
@@ -314,13 +329,9 @@ if (program.listen) {
       }
     });
 
-    ws.on('close', (code) => {
+    ws.on('close', (code, reason) => {
       if (!program.execute) {
-        wsConsole.print(
-          Console.Types.Control,
-          `Disconnected (code: ${code})`,
-          Console.Colors.Green
-        );
+        wsConsole.printClose(code, reason);
       }
       wsConsole.clear();
       process.exit();


### PR DESCRIPTION
builds on top of #109

Removed the `-r,--print-reason` argument. The reason is always printed