### PR TITLE
add --show-ping to display ping, disabling it by default

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ Options:
   -o, --origin <origin>               optional origin
   -x, --execute <command>             execute command after connecting
   -w, --wait <seconds>                wait given seconds after executing command
-  -P, --show-ping                     print internal ping/pong messages
+  -P, --show-ping                     print a notification when a ping or pong is received
   --host <host>                       optional host
   -s, --subprotocol <protocol>        optional subprotocol (default: [])
   -n, --no-check                      do not check for unauthorized certificates

--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ Options:
   -o, --origin <origin>               optional origin
   -x, --execute <command>             execute command after connecting
   -w, --wait <seconds>                wait given seconds after executing command
-  -P, --hide-ping                     hide internal ping/pong messages
+  -P, --show-ping                     print internal ping/pong messages
   --host <host>                       optional host
   -s, --subprotocol <protocol>        optional subprotocol (default: [])
   -n, --no-check                      do not check for unauthorized certificates

--- a/README.md
+++ b/README.md
@@ -23,6 +23,7 @@ Options:
   -o, --origin <origin>               optional origin
   -x, --execute <command>             execute command after connecting
   -w, --wait <seconds>                wait given seconds after executing command
+  -P, --hide-ping                     hide internal ping/pong messages
   --host <host>                       optional host
   -s, --subprotocol <protocol>        optional subprotocol (default: [])
   -n, --no-check                      do not check for unauthorized certificates

--- a/bin/wscat
+++ b/bin/wscat
@@ -116,7 +116,10 @@ program
   .option('-o, --origin <origin>', 'optional origin')
   .option('-x, --execute <command>', 'execute command after connecting')
   .option('-w, --wait <seconds>', 'wait given seconds after executing command')
-  .option('-P, --show-ping', 'print internal ping/pong messages')
+  .option(
+    '-P, --show-ping',
+    'print a notification when a ping or pong is received'
+  )
   .option('--host <host>', 'optional host')
   .option('-s, --subprotocol <protocol>', 'optional subprotocol', collect, [])
   .option('-n, --no-check', 'do not check for unauthorized certificates')

--- a/bin/wscat
+++ b/bin/wscat
@@ -116,7 +116,7 @@ program
   .option('-o, --origin <origin>', 'optional origin')
   .option('-x, --execute <command>', 'execute command after connecting')
   .option('-w, --wait <seconds>', 'wait given seconds after executing command')
-  .option('-P, --hide-ping', 'hide internal ping/pong messages')
+  .option('-P, --show-ping', 'print internal ping/pong messages')
   .option('--host <host>', 'optional host')
   .option('-s, --subprotocol <protocol>', 'optional subprotocol', collect, [])
   .option('-n, --no-check', 'do not check for unauthorized certificates')
@@ -337,7 +337,7 @@ if (program.listen) {
     });
 
     ws.on('ping', () => {
-      if (!program.hidePing) {
+      if (program.showPing) {
         wsConsole.print(
           Console.Types.Incoming,
           'Received ping',
@@ -347,7 +347,7 @@ if (program.listen) {
     });
 
     ws.on('pong', () => {
-      if (!program.hidePing) {
+      if (program.showPing) {
         wsConsole.print(
           Console.Types.Incoming,
           'Received pong',

--- a/bin/wscat
+++ b/bin/wscat
@@ -116,6 +116,7 @@ program
   .option('-o, --origin <origin>', 'optional origin')
   .option('-x, --execute <command>', 'execute command after connecting')
   .option('-w, --wait <seconds>', 'wait given seconds after executing command')
+  .option('-P, --hide-ping', 'hide internal ping/pong messages')
   .option('--host <host>', 'optional host')
   .option('-s, --subprotocol <protocol>', 'optional subprotocol', collect, [])
   .option('-n, --no-check', 'do not check for unauthorized certificates')
@@ -336,19 +337,23 @@ if (program.listen) {
     });
 
     ws.on('ping', () => {
-      wsConsole.print(
-        Console.Types.Incoming,
-        'Received ping',
-        Console.Colors.Blue
-      );
+      if (!program.hidePing) {
+        wsConsole.print(
+          Console.Types.Incoming,
+          'Received ping',
+          Console.Colors.Blue
+        );
+      }
     });
 
     ws.on('pong', () => {
-      wsConsole.print(
-        Console.Types.Incoming,
-        'Received pong',
-        Console.Colors.Blue
-      );
+      if (!program.hidePing) {
+        wsConsole.print(
+          Console.Types.Incoming,
+          'Received pong',
+          Console.Colors.Blue
+        );
+      }
     });
 
     wsConsole.on('close', () => {


### PR DESCRIPTION
builds on #110 

`--show-ping` still uses the `-P` shortcut, which might be confusing