### PR TITLE
Preserve cursor on input line and display server sent messages from the beginning of each line.

### DIFF
--- a/bin/wscat
+++ b/bin/wscat
@@ -61,7 +61,7 @@ class Console extends EventEmitter {
   }
 
   prompt() {
-    this.readlineInterface.prompt();
+    this.readlineInterface.prompt(true);
   }
 
   print(type, msg, color) {

--- a/bin/wscat
+++ b/bin/wscat
@@ -82,7 +82,7 @@ class Console extends EventEmitter {
 
   clear() {
     if (tty.isatty(1)) {
-      this.stdout.write('\u001b[2K\u001b[3D');
+      this.stdout.write('\r\u001b[2K\u001b[3D');
     }
   }
 


### PR DESCRIPTION
Thanks for this useful tool.
Currently, we cannot type correctly while receiving messages from the server. With each message received from the server, the current cursor position will reset. Received messages also not displaying correctly.
```bash
Connected (press CTRL+C to quit)
    < tick
 < tick
     < tick
    < tick
    < tick
   < tick
     < tick
    < tick
    < tick
> .erverrom sages fmessving receiwhile g typin
```
This PR fixed these two bugs. The new output is this:

```bash
Connected (press CTRL+C to quit)
< tick
< tick
< tick
< tick
< tick
< tick
< tick
< tick
< tick
< tick
> typing while receiving messages from the server.
```