### PR TITLE
fix error reporting when console output is redirected

### DIFF
--- a/bin/wscat
+++ b/bin/wscat
@@ -76,7 +76,7 @@ class Console extends EventEmitter {
     } else if (type === Console.Types.Incoming) {
       this.stdout.write(msg + '\n');
     } else {
-      // is a control message and we're not in a tty... drop it.
+      this.stdout.write(type + msg + '\n');
     }
   }
 

--- a/bin/wscat
+++ b/bin/wscat
@@ -26,6 +26,7 @@ class Console extends EventEmitter {
 
     this.stdin = process.stdin;
     this.stdout = process.stdout;
+    this.stderr = process.stderr;
 
     this.readlineInterface = readline.createInterface(this.stdin, this.stdout);
 
@@ -75,8 +76,10 @@ class Console extends EventEmitter {
       this.prompt();
     } else if (type === Console.Types.Incoming) {
       this.stdout.write(msg + '\n');
+    } else if (type === Console.Types.Error) {
+      this.stderr.write(type + msg + '\n');
     } else {
-      this.stdout.write(type + msg + '\n');
+      // is a control message and we're not in a tty... drop it.
     }
   }
 


### PR DESCRIPTION
When wscat is used in a script, it is useful to catch errors. Currently wscat doesn't print any errors when console output is redirected. This commit fixes it.