### PR TITLE
[feature] Handle data in ping/pong frames

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ Options:
   --passphrase [passphrase]           specify a Client SSL Certificate Key's passphrase (--connect only). If you don't
                                       provide a value, it will be prompted for
   --proxy <[protocol://]host[:port]>  connect via a proxy. Proxy must support CONNECT method
-  --slash                             enable slash commands for control frames (/ping, /pong, /close [code [, reason]])
+  --slash                             enable slash commands for control frames (/ping [data], /pong [data], /close [code [, reason]])
   -c, --connect <url>                 connect to a WebSocket server
   -H, --header <header:value>         set an HTTP header. Repeat to set multiple (--connect only) (default: [])
   -L, --location                      follow redirects (--connect only)

--- a/README.md
+++ b/README.md
@@ -27,7 +27,8 @@ Options:
   --passphrase [passphrase]           specify a Client SSL Certificate Key's passphrase (--connect only). If you don't
                                       provide a value, it will be prompted for
   --proxy <[protocol://]host[:port]>  connect via a proxy. Proxy must support CONNECT method
-  --slash                             enable slash commands for control frames (/ping [data], /pong [data], /close [code [, reason]])
+  --slash                             enable slash commands for control frames (/ping [data], /pong [data], /close
+                                      [code [, reason]])
   -c, --connect <url>                 connect to a WebSocket server
   -H, --header <header:value>         set an HTTP header. Repeat to set multiple (--connect only) (default: [])
   -L, --location                      follow redirects (--connect only)

--- a/bin/wscat
+++ b/bin/wscat
@@ -138,8 +138,8 @@ program
   )
   .option(
     '--slash',
-    'enable slash commands for control frames (/ping, /pong, /close ' +
-      '[code [, reason]])'
+    'enable slash commands for control frames (/ping [data], /pong [data], ' +
+      '/close [code [, reason]])'
   )
   .option('-c, --connect <url>', 'connect to a WebSocket server')
   .option(
@@ -292,11 +292,19 @@ if (programOptions.listen) {
           if (programOptions.slash && data[0] === '/') {
             const toks = data.split(/\s+/);
             switch (toks[0].substr(1)) {
-              case 'ping':
-                ws.ping(noop);
+            case 'ping':
+                if (toks.length >= 2) {
+                    ws.ping(toks[1]);
+                } else {
+                    ws.ping(noop);
+                }
                 break;
-              case 'pong':
-                ws.pong(noop);
+            case 'pong':
+                if (toks.length >= 2) {
+                    ws.pong(toks[1]);
+                } else {
+                    ws.pong(noop);
+                }
                 break;
               case 'close': {
                 let closeStatusCode = 1000;
@@ -350,21 +358,21 @@ if (programOptions.listen) {
       wsConsole.print(Console.Types.Incoming, data, Console.Colors.Blue);
     });
 
-    ws.on('ping', () => {
+    ws.on('ping', (data) => {
       if (programOptions.showPingPong) {
         wsConsole.print(
           Console.Types.Incoming,
-          'Received ping',
+          `Received ping (data: "${data}"`,
           Console.Colors.Blue
         );
       }
     });
 
-    ws.on('pong', () => {
+    ws.on('pong', (data) => {
       if (programOptions.showPingPong) {
         wsConsole.print(
           Console.Types.Incoming,
-          'Received pong',
+          `Received pong (data: "${data}")`,
           Console.Colors.Blue
         );
       }


### PR DESCRIPTION
Add ability to send ping/pong frames with application data attached (as per RFC6455, section 5.5.2 and 5.5.3).
Also, when such frames are received, application data (if any) is displayed in the console.
Example:
```
$ bin/wscat -c ws://127.0.0.1:80 --slash -P
Connected (press CTRL+C to quit)
> /ping
< Received pong (data: "")
> /ping foo
< Received pong (data: "foo")
```