### PR TITLE
Added support for multiline JSON parsing

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,6 +32,7 @@ Options:
   -c, --connect <url>                 connect to a WebSocket server
   -H, --header <header:value>         set an HTTP header. Repeat to set multiple (--connect only) (default: [])
   -L, --location                      follow redirects (--connect only)
+  -j, --json                          parse multiline JSON
   -l, --listen <port>                 listen on port
   -n, --no-check                      do not check for unauthorized certificates
   -o, --origin <origin>               optional origin

--- a/bin/wscat
+++ b/bin/wscat
@@ -58,6 +58,12 @@ class Console extends EventEmitter {
   }
 
   prompt() {
+    this.readlineInterface.setPrompt('> ');
+    this.readlineInterface.prompt(true);
+  }
+
+  multilinePrompt() {
+    this.readlineInterface.setPrompt('| ');
     this.readlineInterface.prompt(true);
   }
 
@@ -91,6 +97,82 @@ class Console extends EventEmitter {
 
   resume() {
     this.stdin.removeListener('keypress', this._resetInput);
+  }
+}
+
+class JsonInputHandler {
+  constructor({
+    ws,
+    wsConsole,
+  }) {
+    this.ws = ws;
+    this.wsConsole = wsConsole;
+    this.maxEmptyLines = 2;
+
+    this.emptyLineCount = 0;
+    this.inputList = [];
+  }
+
+  get hasExceededMaxLines() {
+    return this.emptyLineCount >= this.maxEmptyLines;
+  }
+
+  get hasPartialJson() {
+    return this.inputList.length !== 0;
+  }
+
+  reset() {
+    this.emptyLineCount = 0;
+    this.inputList = [];
+  }
+
+  attemptParseAndSend() {
+    const jsonStr = this.inputList.join('\n');
+    JSON.parse(jsonStr);
+    this.ws.send(jsonStr);
+    this.wsConsole.prompt();
+    this.reset();
+  }
+
+  recoverFromParseError(error) {
+    if (error.message.match(/Unexpected end of JSON input/i)) {
+      this.wsConsole.multilinePrompt();
+    } else if (error.message.match(/Unexpected/)) {
+      this.wsConsole.print(Console.Types.Error, 'Illegal JSON text ', Console.Colors.Yellow );
+      this.reset();
+      this.wsConsole.prompt();
+    }
+  }
+
+  resetFromMaxEmptyLines() {
+    this.reset();
+    this.wsConsole.print(
+      Console.Types.Control,
+      'You typed two empty lines, resetting JSON text.',
+      Console.Colors.Default,
+    );
+  }
+
+  handle(data) {
+    if (data.trim() === '') {
+      if (this.hasPartialJson) {
+        this.emptyLineCount++;
+        if (this.hasExceededMaxLines) {
+          this.resetFromMaxEmptyLines();
+        } else {
+          this.wsConsole.multilinePrompt();
+        }
+      } else {
+        this.wsConsole.prompt();
+      }
+    } else {
+      this.inputList.push(data);
+      try {
+        this.attemptParseAndSend();
+      } catch (error) {
+        this.recoverFromParseError(error);
+      }
+    }
   }
 }
 
@@ -148,6 +230,7 @@ program
     collect,
     []
   )
+  .option('-j, --json', 'parse multiline JSON')
   .option('-L, --location', 'follow redirects (--connect only)')
   .option('-l, --listen <port>', 'listen on port')
   .option('-n, --no-check', 'do not check for unauthorized certificates')
@@ -271,6 +354,10 @@ if (programOptions.listen) {
     }
 
     const ws = new WebSocket(connectUrl, programOptions.subprotocol, options);
+    const jsonHandler = new JsonInputHandler({
+      ws,
+      wsConsole,
+    });
 
     ws.on('open', () => {
       if (programOptions.execute) {
@@ -329,10 +416,13 @@ if (programOptions.listen) {
                   Console.Colors.Yellow
                 );
             }
+            wsConsole.prompt();
+          } else if (programOptions.json) {
+            jsonHandler.handle(data);
           } else {
             ws.send(data);
+            wsConsole.prompt();
           }
-          wsConsole.prompt();
         });
       }
     });


### PR DESCRIPTION
It is pretty common to send JSON over websockets, and it can be rather limiting to be forced to "minify" the JSON string, especially for local testing. The new '-j --json' flag is supposed to alleviate that. The primary way this is alleviated is by allowing for multiline inputs. Secondarily, by leveraging the built in `JSON.parse()` method we can check to see if the inputs produce a valid JSON string, and determine that the multiline input is terminated. Finally, as inspired by the Scala REPL, two consecutive empty lines resets the input.

Here are some samples of what this looks like while it is running:
```
$ wscat -j -c ws://websocket-echo.com
Connected (press CTRL+C to quit)
> {}
< {}
> []
< []
> {
|   "foo": "bar",
|   "hello": "world"
| }
< {
  "foo": "bar",
  "hello": "world"
}
> 42
< 42
> "hello world"
< "hello world"
> [
|   1,
|   2
|   ,3]
< [
  1,
  2
  ,3]
```