### PR TITLE
fix: Missing parenthesis in ping log

### DIFF
--- a/bin/wscat
+++ b/bin/wscat
@@ -362,7 +362,7 @@ if (programOptions.listen) {
       if (programOptions.showPingPong) {
         wsConsole.print(
           Console.Types.Incoming,
-          `Received ping (data: "${data}"`,
+          `Received ping (data: "${data}")`,
           Console.Colors.Blue
         );
       }


### PR DESCRIPTION
As in the title, small fix for missing closing parenthesis in ping/pong log