### PR TITLE
add option -b/--binary for communicate with WebSocket server by binary data

### DIFF
--- a/bin/wscat
+++ b/bin/wscat
@@ -138,6 +138,7 @@ program
     'enable slash commands for control frames (/ping [data], /pong [data], ' +
       '/close [code [, reason]]) (--connect only)'
   )
+  .option('-b, --binary', 'communicate with WebSocket server by binary data')
   .option('-c, --connect <url>', 'connect to a WebSocket server')
   .option(
     '-H, --header <header:value>',
@@ -198,6 +199,7 @@ if (programOptions.listen) {
 
   wsConsole.on('line', (data) => {
     if (ws) {
+      if (programOptions.binary) data = Buffer.from(data, 'hex');
       ws.send(data);
       wsConsole.prompt();
     }
@@ -231,6 +233,7 @@ if (programOptions.listen) {
     });
 
     ws.on('message', (data) => {
+      if (programOptions.binary) data = data.toString('hex');
       wsConsole.print(Console.Types.Incoming, data, Console.Colors.Blue);
     });
   });
@@ -338,6 +341,7 @@ if (programOptions.listen) {
                 );
             }
           } else {
+            if (programOptions.binary) data = Buffer.from(data, 'hex');
             ws.send(data);
           }
           wsConsole.prompt();
@@ -363,6 +367,7 @@ if (programOptions.listen) {
     });
 
     ws.on('message', (data) => {
+      if (programOptions.binary) data = data.toString('hex');
       wsConsole.print(Console.Types.Incoming, data, Console.Colors.Blue);
     });
 


### PR DESCRIPTION
![iShot_2024-12-03_08 10 41](https://github.com/user-attachments/assets/ac97995a-34ec-4b4b-95e4-eda7d7c18f4c)

```
wscat -c wss://my_server.com
vs
wscat -b -c wss://my_server.com
```