### PR TITLE
Fix usage of execute option when no stdin

### DIFF
--- a/bin/wscat
+++ b/bin/wscat
@@ -399,10 +399,12 @@ if (programOptions.listen) {
       }
     });
 
-    wsConsole.on('close', () => {
-      ws.close();
-      process.exit();
-    });
+    if (!programOptions.execute.length) {
+      wsConsole.on('close', () => {
+        ws.close();
+        process.exit();
+      });
+    }
   };
 
   if (programOptions.passphrase === true) {


### PR DESCRIPTION
Current implementation returns immediatly when used with execute option in an environment without stdin (see #141), this fix it.